### PR TITLE
fix(AGENTS.md): correct nvm path and add build scripts note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,20 +8,20 @@ BRB UI is a React component library monorepo (pnpm + Turborepo). It contains pub
 
 ### Prerequisites
 
-- **Node.js** (version specified in `.nvmrc`). Load via `export NVM_DIR="$HOME/.nvm" && source "$NVM_DIR/nvm.sh"`.
+- **Node.js** (version specified in `.nvmrc`). Load via `export NVM_DIR="/home/ubuntu/.nvm" && source "$NVM_DIR/nvm.sh"`.
 - **pnpm** via Corepack（版本由 `package.json` 的 `packageManager` 字段管理，无需手动安装）。
 
 ### Key commands
 
-| Task | Command | Notes |
-|---|---|---|
-| Install deps | `pnpm install` | |
-| Build packages | `pnpm build:packages` | Builds only `packages/*` via tsup |
-| Lint | `pnpm lint` | oxlint on `packages`, `tools`, `docs/storybook` |
-| Format check | `pnpm format:check` | oxfmt |
-| Tests | `pnpm test` | Jest (currently only `packages/button/tests`) |
-| Type check | `pnpm typecheck` | `tsc --noEmit` |
-| Storybook dev | `pnpm dev:storybook` | Port 8000 |
+| Task           | Command               | Notes                                           |
+| -------------- | --------------------- | ----------------------------------------------- |
+| Install deps   | `pnpm install`        |                                                 |
+| Build packages | `pnpm build:packages` | Builds only `packages/*` via tsup               |
+| Lint           | `pnpm lint`           | oxlint on `packages`, `tools`, `docs/storybook` |
+| Format check   | `pnpm format:check`   | oxfmt                                           |
+| Tests          | `pnpm test`           | Jest (currently only `packages/button/tests`)   |
+| Type check     | `pnpm typecheck`      | `tsc --noEmit`                                  |
+| Storybook dev  | `pnpm dev:storybook`  | Port 8000                                       |
 
 ### Known pre-existing issues
 
@@ -32,3 +32,4 @@ BRB UI is a React component library monorepo (pnpm + Turborepo). It contains pub
 
 - Husky pre-commit hook calls `yarn lint-staged` (not pnpm). Husky may not be installed in the Cloud Agent environment; this is fine since lint/format are run explicitly.
 - After `pnpm install`, packages must be built (`pnpm build:packages`) before Storybook or examples can run, because workspace packages reference `dist/` outputs.
+- `pnpm install` shows "Ignored build scripts" warnings for `@swc/core`, `esbuild`, etc. This does NOT block development — `@swc/core` still works via pre-built binaries and `esbuild` is not needed at runtime for library builds or tests.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

- Fixed the nvm path from `$HOME/.nvm` to `/home/ubuntu/.nvm` (the actual location in the Cloud Agent environment).
- Added a note clarifying that "Ignored build scripts" warnings during `pnpm install` are non-blocking.

## Context

During environment setup, the documented nvm path (`$HOME/.nvm`) did not resolve correctly because nvm is installed under `/home/ubuntu/.nvm`. This fix ensures future agents can load nvm without issues.

The build scripts warning note helps future agents avoid wasting time investigating the `@swc/core`/`esbuild` warnings.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7079e89d-2273-4b3a-bda3-37b5d4e0e2d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7079e89d-2273-4b3a-bda3-37b5d4e0e2d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

